### PR TITLE
Feature/iterator callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ __Parameters__:
 
 * `dir`: absolute directory
 * `options`: optional, properties: `{ recursive: [default is true] }`
-* `iterator`: function(path, stats), where stats is an instance of fs.Stats
+* `iterator`: function(path, stats, next), where stats is an instance of fs.Stats
 * `callback`: function(err)
 
 Return false from the iterator to stop walking.
@@ -20,9 +20,9 @@ Return false from the iterator to stop walking.
 ```javascript
 var walk = require('walk-fs');
 
-walk(__dirname, function(path, stats) {
+walk(__dirname, function(path, stats, next) {
   console.log(path, stats);
-
+  next();
 }, function(err) {
   assert(!err);
 });

--- a/index.js
+++ b/index.js
@@ -32,26 +32,27 @@ function walk(dir, options, iterator, callback) {
         if (options.stop) return;
         if (err) return handleError(options, callback, err);
         
-        var ret = iterator(item, stats);
-        if (typeof ret === 'boolean' && ret === false) {
-          options.stop = true;
-          return callback();
-        }
+        iterator(item, stats, function(ret){
+          if (typeof ret === 'boolean' && ret === false) {
+            options.stop = true;
+            return callback();
+          }
 
-        if (stats.isDirectory() && options.recursive) {
+          if (stats.isDirectory() && options.recursive) {
 
-          return walk(item, options, iterator, function(err) {
-            if (options.stop) return;
-            if (err) return handleError(options, callback, err);
+            return walk(item, options, iterator, function(err) {
+              if (options.stop) return;
+              if (err) return handleError(options, callback, err);
             
-            if (--numItems === 0) {
-              callback();
-            }
-          });
-        }
-        if (--numItems === 0) {
-          callback();
-        }
+              if (--numItems === 0) {
+                callback();
+              }
+            });
+          }
+          if (--numItems === 0) {
+            callback();
+          }
+        });  
       });
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -22,9 +22,9 @@ describe('walk-fs', function() {
       return path.join(__dirname, item);
     });
     
-    walk(path.join(__dirname, 'a'), function(path, stats) {
+    walk(path.join(__dirname, 'a'), function(path, stats, next) {
       assert(removeItem(items, path));
-      
+      next();
     }, function(err) {
       assert(!err);
       assert(items.length === 0);
@@ -41,9 +41,9 @@ describe('walk-fs', function() {
       return path.join(__dirname, item);
     });
     
-    walk(path.join(__dirname, 'a'), { recursive: false }, function(path, stats) {
+    walk(path.join(__dirname, 'a'), { recursive: false }, function(path, stats, next) {
       assert(removeItem(items, path));
-
+	  next();
     }, function(err) {
       assert(!err);
       assert(items.length === 0);
@@ -56,9 +56,9 @@ describe('walk-fs', function() {
 
     var calls = 0;
     
-    walk(path.join(__dirname, 'a'), function(path, stats) {
+    walk(path.join(__dirname, 'a'), function(path, stats, next) {
       ++calls;
-      return false;
+      next(false);
       
     }, function(err) {
       assert(!err);
@@ -70,9 +70,9 @@ describe('walk-fs', function() {
 
   it('should invoke the callback on error', function(done) {
 
-    walk(path.join(__dirname, 'not'), function(path, stats) {
+    walk(path.join(__dirname, 'not'), function(path, stats, next) {
       assert(false);
-      
+      next();
     }, function(err) {
       assert(err);
       done();


### PR DESCRIPTION
Related to Issue #1 

The iterator needs a callback, because what we do with files is open them and read the content. This all works asynchron. but walk() do not wait for the clients code to tell that an operation is finished, so it come back to early in its own end() function. 

UnitTests that depends on the result of the fs.readFile will fail, because the fs is slower than the execution. 

I think i fixed it ;) 
